### PR TITLE
The props.index is used to seed the Animation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default class Swiper extends Component {
 
     this.state = {
       index: props.index,
-      scrollValue: new Animated.Value(0),
+      scrollValue: new Animated.Value(props.index),
       viewWidth: Dimensions.get('window').width,
     }
   }


### PR DESCRIPTION
If you do not do this and start on say, the right-most page, the initial pan is pretty jarring.