### PR TITLE
Actually hide other views

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ export default class Swiper extends Component {
     }
 
     return (
-      <View style={{flex: 1}} onLayout={this.handleLayout.bind(this)}>
+      <View style={{flex: 1, overflow: "hidden"}} onLayout={this.handleLayout.bind(this)}>
         <Animated.View
           {...this._panResponder.panHandlers}
           style={[sceneContainerStyle, {transform: [{translateX}]}]}


### PR DESCRIPTION
When using react-native-side-menu[1] previous slide was pulled to view
instead of the menu.

[1]: https://github.com/react-native-fellowship/react-native-side-menu