### PR TITLE
Implement controlled usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ AppRegistry.registerComponent('swiper', () => swiper)
 
 | Prop  | Default  | Type | Description |
 | :------------ |:---------------:| :---------------:| :-----|
-| index | `0` | `number` | Index number of initial slide. |
+| index | | `number` | Show slide in this index. |
+| initialIndex | `0` | `number` | Index number of initial slide. Not applicable with `index`.|
 | pager | `true` | `boolean` | Show pager. |
-| onPageChange |  | `function` | Callback when page changes. |
+| onPageChange |  | `function` | Callback when page changes or change is requested if `index` is set. |
 | activeDotColor | `blue` | `string` | CSS color of the dot for the current page. |
 
 


### PR DESCRIPTION
and rename index prop to initialIndex.

Maybe a bit lame implementation as it just syncs the prop to state but the changeset for this was trivial and from the consumer's perspective the is api stateless.

Closes https://github.com/fixt/react-native-page-swiper/issues/5
